### PR TITLE
Encodes username and password for GitHubUrl function

### DIFF
--- a/GitHubBackup/GitHubBackup.vbproj
+++ b/GitHubBackup/GitHubBackup.vbproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <Import Include="Microsoft.VisualBasic" />

--- a/GitHubBackup/Module1.vb
+++ b/GitHubBackup/Module1.vb
@@ -237,8 +237,8 @@ markExit:
     End Function
 
     Function GitHubUrl(userID As String, pw As String) As String
-      Return "https://" & userID & ":" & pw & "@github.com/" & Owner & "/" & Name
-    End Function
+            Return "https://" & Web.HttpUtility.UrlEncode(userID) & ":" & Web.HttpUtility.UrlEncode(pw) & "@github.com/" & Owner & "/" & Name
+        End Function
 
   End Class
 


### PR DESCRIPTION
URL encode the username and password to fix error message when using email as username
should fix the same problem when username or password uses @ : / space 